### PR TITLE
fix: insert instead of upsert and do not use role id as userRole id

### DIFF
--- a/src/wwPlugin.js
+++ b/src/wwPlugin.js
@@ -143,7 +143,7 @@ export default {
         for (const role of roles) {
             const { error } = await this.privateInstance
                 .from(this.settings.publicData.userRoleTable)
-                .upsert({ id: role.id, roleId: role.id, userId: user.id });
+                .insert({ roleId: role.id, userId: user.id });
             if (error) throw new Error(error.message, { cause: error });
         }
     },


### PR DESCRIPTION
Using the role id as identifier for the relationship in the database combined with an upsert created wrong behavior